### PR TITLE
feat: descend into MulOp operands in the symbol visitor

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -242,6 +242,9 @@ fn visit_data_expr<'a>(
         tx3_lang::ast::DataExpr::SubOp(op) => {
             visit_data_expr(&op.lhs, offset).or_else(|| visit_data_expr(&op.rhs, offset))
         }
+        tx3_lang::ast::DataExpr::MulOp(op) => {
+            visit_data_expr(&op.lhs, offset).or_else(|| visit_data_expr(&op.rhs, offset))
+        }
         tx3_lang::ast::DataExpr::ConcatOp(op) => {
             visit_data_expr(&op.lhs, offset).or_else(|| visit_data_expr(&op.rhs, offset))
         }


### PR DESCRIPTION
## Summary

Teaches the symbol visitor about the new `MulOp` AST node so hover and go-to-definition descend into both operands of a `*` expression (mirrors the existing `AddOp`/`SubOp` arms).

## Depends on

tx3-lang/tx3#339 (`DataExpr::MulOp`). Bump the `tx3-lang` dependency to the release that includes it before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
