### PR TITLE
feat: descend into DivOp operands in the symbol visitor

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -245,6 +245,9 @@ fn visit_data_expr<'a>(
         tx3_lang::ast::DataExpr::MulOp(op) => {
             visit_data_expr(&op.lhs, offset).or_else(|| visit_data_expr(&op.rhs, offset))
         }
+        tx3_lang::ast::DataExpr::DivOp(op) => {
+            visit_data_expr(&op.lhs, offset).or_else(|| visit_data_expr(&op.rhs, offset))
+        }
         tx3_lang::ast::DataExpr::ConcatOp(op) => {
             visit_data_expr(&op.lhs, offset).or_else(|| visit_data_expr(&op.rhs, offset))
         }


### PR DESCRIPTION
## Summary

Adds the `tx3_lang::ast::DataExpr::DivOp` arm to `visit_data_expr` (`src/visitor.rs`), so LSP hover / go-to-definition recurse into both operands of the new `/` operator — identical to the existing `AddOp`/`SubOp`/`MulOp` arms.

## Dependency note

Requires the `DivOp` AST node from **tx3-lang/tx3**; bump `tx3-lang` (and `tx3-tir`) here once they release. Verified compiling via local path patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)