### PR TITLE
feat: recurse into tuple types and tuple literals

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -147,6 +147,9 @@ fn visit_type<'a>(ty: &'a tx3_lang::ast::Type, offset: usize) -> Option<SymbolAt
     match &ty {
         tx3_lang::ast::Type::Custom(id) => visit_identifier(id, offset),
         tx3_lang::ast::Type::List(inner) => visit_type(inner, offset),
+        tx3_lang::ast::Type::Tuple(elements) => {
+            elements.iter().find_map(|inner| visit_type(inner, offset))
+        }
         _ => None,
     }
 }
@@ -219,6 +222,14 @@ fn visit_data_expr<'a>(
         tx3_lang::ast::DataExpr::StructConstructor(sc) => visit_struct_constructor(sc, offset),
         tx3_lang::ast::DataExpr::ListConstructor(lc) => {
             for el in &lc.elements {
+                if let Some(sym) = visit_data_expr(el, offset) {
+                    return Some(sym);
+                }
+            }
+            None
+        }
+        tx3_lang::ast::DataExpr::TupleConstructor(tc) => {
+            for el in &tc.elements {
                 if let Some(sym) = visit_data_expr(el, offset) {
                     return Some(sym);
                 }


### PR DESCRIPTION
## Summary

`tx3-lang` adds parametric tuple types (`Tuple<T1, ..., Tn>`) and a tuple-literal expression (`(e1, e2, ...)`). This teaches the LSP symbol visitor to descend into both, so go-to-definition and hover resolve symbols nested inside tuples:

- `visit_type` recurses into each `Type::Tuple` element type.
- `visit_data_expr` handles `DataExpr::TupleConstructor`, recursing into its elements (mirrors the existing `ListConstructor` arm).

## Release ordering

Depends on the **tx3-lang** release with tuple types (tx3-lang/tx3#341). Merge after that releases and bump the `tx3-lang` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
