### PR TITLE
ci: make CI green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -16,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
         with:
           components: rustfmt
@@ -27,6 +36,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
         with:
           components: clippy
@@ -43,6 +54,8 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@1.91
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace --all-targets --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,4 @@ push = false
 publish = false
 tag-name = "v{{version}}"
 pre-release-commit-message = "release: v{{version}}"
-pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--latest"]
+pre-release-hook = ["git", "cliff", "-o", "CHANGELOG.md", "--tag", "v{{version}}"]

--- a/src/cmds/generate_ast.rs
+++ b/src/cmds/generate_ast.rs
@@ -12,7 +12,7 @@ impl TryFrom<Vec<Value>> for Args {
     fn try_from(value: Vec<Value>) -> Result<Self, Self::Error> {
         Ok(Args {
             document_url: value
-                .get(0)
+                .first()
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_owned())
                 .ok_or(Error::InvalidCommandArgs("document_url".to_string()))?,

--- a/src/cmds/generate_diagram.rs
+++ b/src/cmds/generate_diagram.rs
@@ -11,7 +11,7 @@ impl TryFrom<Vec<Value>> for Args {
     fn try_from(value: Vec<Value>) -> Result<Self, Self::Error> {
         Ok(Args {
             document_url: value
-                .get(0)
+                .first()
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_owned())
                 .ok_or(Error::InvalidCommandArgs("document_url".to_string()))?,

--- a/src/cmds/generate_tir.rs
+++ b/src/cmds/generate_tir.rs
@@ -1,6 +1,6 @@
+use crate::{Context, Error};
 use serde_json::{json, Value};
 use tx3_tir::reduce::Apply;
-use crate::{Context, Error};
 
 #[derive(Debug)]
 pub struct Args {

--- a/src/cmds/generate_tir.rs
+++ b/src/cmds/generate_tir.rs
@@ -14,7 +14,7 @@ impl TryFrom<Vec<Value>> for Args {
     fn try_from(value: Vec<Value>) -> Result<Self, Self::Error> {
         Ok(Args {
             document_url: value
-                .get(0)
+                .first()
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_owned())
                 .ok_or(Error::InvalidCommandArgs("document_url".to_string()))?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,7 +343,8 @@ impl Context {
 
     fn get_document_program(&self, url_arg: &str) -> Result<tx3_lang::ast::Program, Error> {
         let document = self.get_document(url_arg)?;
-        tx3_lang::parsing::parse_string(document.to_string().as_str()).map_err(Error::ProgramParsingError)
+        tx3_lang::parsing::parse_string(document.to_string().as_str())
+            .map_err(Error::ProgramParsingError)
     }
 
     async fn process_document(&self, uri: Url, text: &str) -> Vec<Diagnostic> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -193,60 +193,40 @@ impl Context {
                         }
                         processed_spans.insert(span_key);
 
-                        let token_type = if ast
-                            .parties
-                            .iter()
-                            .any(|p| p.name.value == identifier.value)
-                        {
-                            TOKEN_PARTY
-                        } else if ast
-                            .policies
-                            .iter()
-                            .any(|p| p.name.value == identifier.value)
-                        {
-                            TOKEN_POLICY
-                        } else if ast.types.iter().any(|t| t.name.value == identifier.value) {
-                            TOKEN_TYPE
-                        } else if Context::is_type_field_reference(ast, &identifier.value, offset) {
-                            TOKEN_TYPE
-                        } else if ast.assets.iter().any(|a| a.name.value == identifier.value) {
-                            TOKEN_CLASS
-                        } else if ast
-                            .functions
-                            .iter()
-                            .any(|f| f.name.value == identifier.value)
-                        {
-                            // Both a function's declaration name and any call-site
-                            // callee resolve here, since they share the identifier.
-                            TOKEN_FUNCTION
-                        } else {
-                            let mut found_type = None;
+                        let token_type =
+                            if ast.parties.iter().any(|p| p.name.value == identifier.value) {
+                                TOKEN_PARTY
+                            } else if ast
+                                .policies
+                                .iter()
+                                .any(|p| p.name.value == identifier.value)
+                            {
+                                TOKEN_POLICY
+                            } else if ast.types.iter().any(|t| t.name.value == identifier.value)
+                                || Context::is_type_field_reference(ast, &identifier.value, offset)
+                            {
+                                TOKEN_TYPE
+                            } else if ast.assets.iter().any(|a| a.name.value == identifier.value) {
+                                TOKEN_CLASS
+                            } else if ast
+                                .functions
+                                .iter()
+                                .any(|f| f.name.value == identifier.value)
+                            {
+                                // Both a function's declaration name and any call-site
+                                // callee resolve here, since they share the identifier.
+                                TOKEN_FUNCTION
+                            } else {
+                                let mut found_type = None;
 
-                            for tx in &ast.txs {
-                                if tx.name.value == identifier.value {
-                                    found_type = Some(TOKEN_FUNCTION);
-                                    break;
-                                }
-
-                                if crate::span_contains(&tx.span, offset) {
-                                    for param in &tx.parameters.parameters {
-                                        if param.name.value == identifier.value {
-                                            found_type = Some(TOKEN_PARAMETER);
-                                            break;
-                                        }
+                                for tx in &ast.txs {
+                                    if tx.name.value == identifier.value {
+                                        found_type = Some(TOKEN_FUNCTION);
+                                        break;
                                     }
-                                }
 
-                                if found_type.is_some() {
-                                    break;
-                                }
-                            }
-
-                            // Parameters referenced inside a function body.
-                            if found_type.is_none() {
-                                for func in &ast.functions {
-                                    if crate::span_contains(&func.span, offset) {
-                                        for param in &func.parameters.parameters {
+                                    if crate::span_contains(&tx.span, offset) {
+                                        for param in &tx.parameters.parameters {
                                             if param.name.value == identifier.value {
                                                 found_type = Some(TOKEN_PARAMETER);
                                                 break;
@@ -258,10 +238,27 @@ impl Context {
                                         break;
                                     }
                                 }
-                            }
 
-                            found_type.unwrap_or(TOKEN_VARIABLE)
-                        };
+                                // Parameters referenced inside a function body.
+                                if found_type.is_none() {
+                                    for func in &ast.functions {
+                                        if crate::span_contains(&func.span, offset) {
+                                            for param in &func.parameters.parameters {
+                                                if param.name.value == identifier.value {
+                                                    found_type = Some(TOKEN_PARAMETER);
+                                                    break;
+                                                }
+                                            }
+                                        }
+
+                                        if found_type.is_some() {
+                                            break;
+                                        }
+                                    }
+                                }
+
+                                found_type.unwrap_or(TOKEN_VARIABLE)
+                            };
 
                         token_infos.push(TokenInfo {
                             range: crate::span_to_lsp_range(rope, &identifier.span),

--- a/src/server.rs
+++ b/src/server.rs
@@ -414,7 +414,7 @@ impl LanguageServer for Context {
                 }
 
                 if span_contains(&tx.parameters.span, offset) {
-                    for param in &tx.parameters.parameters {
+                    if let Some(param) = tx.parameters.parameters.first() {
                         return Ok(Some(Hover {
                             contents: HoverContents::Markup(MarkupContent {
                                 kind: MarkupKind::Markdown,
@@ -439,7 +439,7 @@ impl LanguageServer for Context {
                                 param.name.value, param.r#type
                             ));
                         }
-                        hover_text.push_str("\n");
+                        hover_text.push('\n');
                     }
 
                     if !tx.inputs.is_empty() {
@@ -447,7 +447,7 @@ impl LanguageServer for Context {
                         for input in &tx.inputs {
                             hover_text.push_str(&format!("- `{}`\n", input.name));
                         }
-                        hover_text.push_str("\n");
+                        hover_text.push('\n');
                     }
 
                     if !tx.outputs.is_empty() {
@@ -491,9 +491,9 @@ impl LanguageServer for Context {
                 name,
                 detail: Some(detail),
                 kind,
-                range: range,
+                range,
                 selection_range: range,
-                children: children,
+                children,
                 tags: Default::default(),
                 deprecated: Default::default(),
             }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -1,6 +1,7 @@
 #[derive(Debug)]
 pub enum SymbolAtOffset<'a> {
     Identifier(&'a tx3_lang::ast::Identifier),
+    #[allow(dead_code)]
     TypeIdentifier(&'a tx3_lang::ast::Type),
 }
 
@@ -423,7 +424,7 @@ fn visit_type_def<'a>(ty: &'a tx3_lang::ast::TypeDef, offset: usize) -> Option<S
         return Some(SymbolAtOffset::Identifier(&ty.name));
     }
     for case in &ty.cases {
-        for field in &case.fields {
+        for _field in &case.fields {
             // TODO: wait for the introduction of `TypeAnnotation` in AST
 
             // if in_span(&field.r#type.span, offset) {


### PR DESCRIPTION
Fixes formatting and clippy issues surfaced by the new CI workflow introduced in the previous hardening PR.

- Run `cargo fmt` to fix formatting
- Fix or allow pre-existing clippy warnings (`dead_code`, `unused_variables`, `result_large_err`, etc.) to unblock the `-D warnings` gate
- Address CodeRabbit review findings from the previous PR:
  - `permissions: contents: read` (least-privilege `GITHUB_TOKEN`)
  - `persist-credentials: false` on all checkout steps
  - `concurrency` group to cancel superseded CI runs
  - `--tag v{{version}}` instead of `--latest` in pre-release-hook